### PR TITLE
Add Bangladesh, Ireland, and Afghanistan teams

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ df = Cricinfo.retrieve_stats(
 | `Team.Pakistan` | Pakistan |
 | `Team.SriLanka` | Sri Lanka |
 | `Team.Zimbabwe` | Zimbabwe |
+| `Team.Bangladesh` | Bangladesh |
+| `Team.Ireland` | Ireland |
+| `Team.Afghanistan` | Afghanistan |
 
 Pass `team=None` to retrieve stats for all teams.
 

--- a/cricinfo/team.py
+++ b/cricinfo/team.py
@@ -15,3 +15,6 @@ class Team(Enum):
     Pakistan = "7"
     SriLanka = "8"
     Zimbabwe = "9"
+    Bangladesh = "25"
+    Ireland = "29"
+    Afghanistan = "40"

--- a/tests/test_team.py
+++ b/tests/test_team.py
@@ -14,6 +14,9 @@ class TestTeam:
             "Pakistan",
             "SriLanka",
             "Zimbabwe",
+            "Bangladesh",
+            "Ireland",
+            "Afghanistan",
         ]
         for team in teams:
             assert team in Team.__members__


### PR DESCRIPTION
## Summary
- Add three new ICC Full Member nations to the `Team` enum: Bangladesh (`25`), Ireland (`29`), and Afghanistan (`40`)
- Update the Supported Teams table in README
- Update team tests to cover the new entries

## Test plan
- [x] All 13 existing tests pass
- [x] `test_teams` validates the three new enum members

🤖 Generated with [Claude Code](https://claude.com/claude-code)